### PR TITLE
Rename some commands to prefix /cf

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,11 @@ async def helpme(inter):
     command_set = bot.get_guild_slash_commands(inter.guild.id)
     help_msg = []
     for cmd in command_set:
-        help_msg.append(cmd.description)
+        if cmd.options:
+            for opt in cmd.options:
+                help_msg.append(opt.description)
+        else:
+            help_msg.append(cmd.description)
     
     await inter.response.send_message(msg + "```" + "\n".join(help_msg) + "```")
 

--- a/src/Codeforces/Commands.py
+++ b/src/Codeforces/Commands.py
@@ -1,4 +1,5 @@
 import json
+from tkinter import N
 import disnake
 import os
 from dotenv import load_dotenv
@@ -12,8 +13,12 @@ class CFCommand(commands.Cog):
         self.bot = bot
 
     @commands.slash_command()
+    async def cf(inter, *args):
+        pass
+
+    @cf.sub_command()
     async def introduce(inter, handle: str):
-        '''/introduce <CF Handle>: Let the bot know your Codeforces handle'''
+        '''/cf introduce <CF Handle>: Let the bot know your Codeforces handle'''
         load_dotenv()
         path = os.environ.get("DATAPATH")
         with open(f"{path}\handle.json", "r+") as json_file:
@@ -24,9 +29,9 @@ class CFCommand(commands.Cog):
             json_file.truncate()
         await inter.response.send_message(f"{inter.author.mention} has been introduced as {handle}")
 
-    @commands.slash_command()
+    @cf.sub_command()
     async def query(inter, dischand: disnake.User):
-        '''/query @<Discord>: Get someone's CF handle'''
+        '''/cf query @<Discord>: Get someone's CF handle'''
         load_dotenv()
         path = os.environ.get("DATAPATH")
         with open(f"{path}\handle.json", "r") as json_file:


### PR DESCRIPTION
Change /introduce and /query to /cf introduce and /cf query respectively.
Updated /helpme to support Subcommand Groups.